### PR TITLE
Update ClickHouse to 26.5.5.8 on kernel528/alpine:3.24.1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -26,12 +26,12 @@ steps:
       repo: kernel528/clickhouse
       tags:
         - latest
-        - '26.1'
-        - '26.1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '26.1.2'
-        - '26.1.2-drone-build-${DRONE_BUILD_NUMBER}-amd64'
-        - '26.1.2.11'
-        - '26.1.2.11-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '26.5'
+        - '26.5-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '26.5.5'
+        - '26.5.5-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '26.5.5.8'
+        - '26.5.5.8-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Slack notification
   - name: slack-notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN arch=${TARGETARCH:-amd64} \
         arm64) ln /lib/linux-gnu/ld-linux-aarch64.so.1 /lib/linux-gnu/ld-2.35.so ;; \
     esac
 
-FROM kernel528/alpine:3.23.3
+FROM kernel528/alpine:3.24.1
 
 # Set to root user to install packages
 USER root
@@ -38,7 +38,7 @@ RUN arch=${TARGETARCH:-amd64} \
 # lts / testing / prestable / etc
 ARG REPO_CHANNEL="stable"
 ARG REPOSITORY="https://packages.clickhouse.com/tgz/${REPO_CHANNEL}"
-ARG VERSION="26.1.2.11"
+ARG VERSION="26.5.5.8"
 ARG PACKAGES="clickhouse-client clickhouse-server clickhouse-common-static"
 ARG DIRECT_DOWNLOAD_URLS=""
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Maintainer: kernel528
 
 ## Overview
-This repository builds an Alpine-based ClickHouse server image from the upstream `Dockerfile.alpine`, but swaps the base to `kernel528/alpine:3.23.3`. Current package version is `26.1.2.11` (stable channel).
+This repository builds an Alpine-based ClickHouse server image from the upstream `Dockerfile.alpine`, but swaps the base to `kernel528/alpine:3.24.1`. Current package version is `26.5.5.8` (stable channel).
 
 Upstream references:
 - https://github.com/ClickHouse/ClickHouse/blob/master/docker/server/Dockerfile.alpine
@@ -23,12 +23,12 @@ Upstream references:
 
 ## Build
 ```bash
-docker build -t kernel528/clickhouse:26.1.2.11 -f Dockerfile .
+docker build -t kernel528/clickhouse:26.5.5.8 -f Dockerfile .
 ```
 
 ## Run
 ```bash
-docker run -d --name clickhouse -p 8123:8123 -p 9000:9000 kernel528/clickhouse:26.1.2.11
+docker run -d --name clickhouse -p 8123:8123 -p 9000:9000 kernel528/clickhouse:26.5.5.8
 ```
 
 ## Refresh Workflow


### PR DESCRIPTION
## Changes

- **Base image**: `kernel528/alpine:3.23.3` → `kernel528/alpine:3.24.1`
- **ClickHouse**: `26.1.2.11` → `26.5.5.8` (latest stable)
- Updated `.drone.yml` tags for `26.5.x`
- Updated `README.md` version references

## Validation

- [x] Image built successfully
- [x] `clickhouse-server --version` → `ClickHouse server version 26.5.5.8 (official build)`
- [x] `cat /etc/alpine-release` → `3.24.1`
- SHA512 checksums verified during build