### PR TITLE
Rebase ClickHouse 26.5.5.8 on Alpine 3.24.1_1

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -32,6 +32,8 @@ steps:
         - '26.5.5-drone-build-${DRONE_BUILD_NUMBER}-amd64'
         - '26.5.5.8'
         - '26.5.5.8-drone-build-${DRONE_BUILD_NUMBER}-amd64'
+        - '26.5.5.8-3.24.1_1'
+        - '26.5.5.8-3.24.1_1-drone-build-${DRONE_BUILD_NUMBER}-amd64'
 
   # Slack notification
   - name: slack-notification

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,7 +12,7 @@ RUN arch=${TARGETARCH:-amd64} \
         arm64) ln /lib/linux-gnu/ld-linux-aarch64.so.1 /lib/linux-gnu/ld-2.35.so ;; \
     esac
 
-FROM kernel528/alpine:3.24.1
+FROM kernel528/alpine:3.24.1_1
 
 # Set to root user to install packages
 USER root

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@
 Maintainer: kernel528
 
 ## Overview
-This repository builds an Alpine-based ClickHouse server image from the upstream `Dockerfile.alpine`, but swaps the base to `kernel528/alpine:3.24.1`. Current package version is `26.5.5.8` (stable channel).
+This repository builds an Alpine-based ClickHouse server image from the upstream `Dockerfile.alpine`, but swaps the base to `kernel528/alpine:3.24.1_1`. Current package version is `26.5.5.8` (stable channel).
 
 Upstream references:
 - https://github.com/ClickHouse/ClickHouse/blob/master/docker/server/Dockerfile.alpine
@@ -23,12 +23,12 @@ Upstream references:
 
 ## Build
 ```bash
-docker build -t kernel528/clickhouse:26.5.5.8 -f Dockerfile .
+docker build -t kernel528/clickhouse:26.5.5.8-3.24.1_1 -f Dockerfile .
 ```
 
 ## Run
 ```bash
-docker run -d --name clickhouse -p 8123:8123 -p 9000:9000 kernel528/clickhouse:26.5.5.8
+docker run -d --name clickhouse -p 8123:8123 -p 9000:9000 kernel528/clickhouse:26.5.5.8-3.24.1_1
 ```
 
 ## Refresh Workflow


### PR DESCRIPTION
## Summary
- rebase ClickHouse 26.5.5.8 on kernel528/alpine:3.24.1_1
- add a base-qualified immutable image tag while preserving existing compatibility tags
- update build and run documentation

## Validation
- built linux/amd64 image with no cache
- verified ClickHouse package SHA512 checksums during build
- ran clickhouse-server --version successfully
- observed version: 26.5.5.8

## Published base
- kernel528/alpine:3.24.1_1
- Docker manifest digest: sha256:1741c5bedfaafd75d3783ad6c51a0a604c52d8ee7eb40e6d083ad9aa3a88c2d6